### PR TITLE
feat: enhance processed documents

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -30,3 +30,43 @@ body.dark {
   background: #1e1e1e;
   color: #fff;
 }
+
+.doc-filters input,
+.doc-filters select {
+  margin-right: 8px;
+}
+
+.doc-table {
+  display: flex;
+}
+
+.doc-table table {
+  flex: 1;
+  border-collapse: collapse;
+}
+
+.doc-table th,
+.doc-table td {
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+}
+
+.doc-table tr.selected {
+  background: #e0e0e0;
+}
+
+.doc-detail {
+  width: 300px;
+  padding-left: 16px;
+  border-left: 1px solid #ccc;
+}
+
+.preview {
+  height: 200px;
+  border: 1px solid #ccc;
+  background: #f9f9f9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 10px;
+}

--- a/server.js
+++ b/server.js
@@ -18,8 +18,36 @@ let users = [
 ];
 
 let documents = [
-  { id: 1, fileName: 'invoice1.pdf', page: 1, type: 'Invoice', dg: false, confidence: 0.95 },
-  { id: 2, fileName: 'msds.pdf', page: 1, type: 'Safety Sheet', dg: true, confidence: 0.86 }
+  {
+    id: 1,
+    fileName: 'invoice1.pdf',
+    page: 1,
+    type: 'Invoice',
+    dg: false,
+    confidence: 0.95,
+    fields: {
+      supplier: { value: 'ACME Corp', confidence: 0.93 },
+      date: { value: '2024-05-01', confidence: 0.88 },
+      items: { value: 'Widgets', confidence: 0.82 },
+      total: { value: '$1,000', confidence: 0.91 },
+      un: { value: 'UN0000', confidence: 0.1 }
+    },
+    preview: ''
+  },
+  {
+    id: 2,
+    fileName: 'msds.pdf',
+    page: 1,
+    type: 'Safety Sheet',
+    dg: true,
+    confidence: 0.86,
+    fields: {
+      supplier: { value: 'Contoso Chemicals', confidence: 0.9 },
+      un: { value: 'UN1234', confidence: 0.95 },
+      hazard: { value: 'Flammable', confidence: 0.84 }
+    },
+    preview: ''
+  }
 ];
 
 let reviewQueue = [
@@ -88,7 +116,9 @@ app.post('/api/ingest', upload.single('file'), (req, res) => {
       page: 1,
       type: 'Uploaded',
       dg: false,
-      confidence: 0
+      confidence: 0,
+      fields: {},
+      preview: ''
     };
     documents.push(doc);
     kafkaStatus.messages += 1;


### PR DESCRIPTION
## Summary
- add sample extracted field data to mock documents API
- introduce filtering and document detail panel on processed documents page
- style document list and side panel with basic layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8d8237400832e9d1fb0cb4e5401d8