### PR TITLE
feat: add TypeScript backend and responsive layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 uploads
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,53 @@
         "multer": "^1.4.5-lts.1"
       },
       "devDependencies": {
-        "supertest": "^6.3.3"
+        "@types/express": "^4.17.21",
+        "@types/multer": "^1.4.7",
+        "@types/node": "^20.11.30",
+        "supertest": "^6.3.3",
+        "ts-node": "^10.9.1",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@noble/hashes": {
@@ -38,6 +84,152 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
+      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -51,10 +243,43 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/array-flatten": {
@@ -243,6 +468,13 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -290,6 +522,16 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -650,6 +892,13 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1200,6 +1449,50 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1217,6 +1510,27 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -1243,6 +1557,13 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1266,6 +1587,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,17 +2,23 @@
   "name": "hdg-portal",
   "version": "0.1.0",
   "description": "Mock HDG portal implementation",
-  "main": "server.js",
+  "main": "server.ts",
   "scripts": {
-    "start": "node server.js",
-    "test": "NODE_ENV=test node --test"
+    "start": "node --loader ts-node/esm server.ts",
+    "build": "tsc",
+    "test": "npm run build && NODE_ENV=test node --test"
   },
   "dependencies": {
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
-    "supertest": "^6.3.3"
+    "@types/express": "^4.17.21",
+    "@types/multer": "^1.4.7",
+    "@types/node": "^20.11.30",
+    "supertest": "^6.3.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
   },
   "type": "module"
 }

--- a/public/app.js
+++ b/public/app.js
@@ -7,18 +7,22 @@ function Sidebar() {
   }, [dark]);
 
   return (
-    <div className="sidebar">
-      <Link to="/">Dashboard</Link>
-      <Link to="/ingestion">Ingestion</Link>
-      <Link to="/documents">Processed Documents</Link>
-      <Link to="/schema">Schema Configuration</Link>
-      <Link to="/review">Review Queue</Link>
-      <Link to="/users">Users</Link>
-      <Link to="/analytics">Analytics</Link>
-      <Link to="/config">Configuration</Link>
+    <nav className="sidebar" aria-label="Main navigation">
+      <ul>
+        <li><Link to="/">Dashboard</Link></li>
+        <li><Link to="/ingestion">Ingestion</Link></li>
+        <li><Link to="/documents">Processed Documents</Link></li>
+        <li><Link to="/schema">Schema Configuration</Link></li>
+        <li><Link to="/review">Review Queue</Link></li>
+        <li><Link to="/users">Users</Link></li>
+        <li><Link to="/analytics">Analytics</Link></li>
+        <li><Link to="/config">Configuration</Link></li>
+      </ul>
       <hr />
-      <button onClick={() => setDark(d => !d)}>{dark ? 'Light' : 'Dark'} Mode</button>
-    </div>
+      <button onClick={() => setDark(d => !d)} aria-label="Toggle color mode">
+        {dark ? 'Light' : 'Dark'} Mode
+      </button>
+    </nav>
   );
 }
 
@@ -181,17 +185,18 @@ function Documents() {
       <h2>Processed Documents</h2>
       <div className="doc-filters">
         <input
+          aria-label="Search file name"
           placeholder="Search file name"
           value={search}
           onChange={e => setSearch(e.target.value)}
         />
-        <select value={type} onChange={e => setType(e.target.value)}>
+        <select aria-label="Filter by type" value={type} onChange={e => setType(e.target.value)}>
           <option value="">All Types</option>
           {types.map(t => (
             <option key={t}>{t}</option>
           ))}
         </select>
-        <select value={dg} onChange={e => setDg(e.target.value)}>
+        <select aria-label="Filter by DG" value={dg} onChange={e => setDg(e.target.value)}>
           <option value="all">DG: All</option>
           <option value="true">DG: Yes</option>
           <option value="false">DG: No</option>
@@ -206,6 +211,17 @@ function Documents() {
             onChange={e => setMinConf(parseInt(e.target.value))}
           />
         </label>
+        <button
+          onClick={() => {
+            setSearch('');
+            setType('');
+            setDg('all');
+            setMinConf(0);
+          }}
+          aria-label="Clear document filters"
+        >
+          Clear Filters
+        </button>
       </div>
       <div className="doc-table">
         <table>
@@ -222,7 +238,11 @@ function Documents() {
             {filtered.map(d => (
               <tr
                 key={d.id}
+                tabIndex="0"
                 onClick={() => setSelected(d)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') setSelected(d);
+                }}
                 className={selected && selected.id === d.id ? 'selected' : ''}
               >
                 <td>{d.fileName}</td>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,6 +1,22 @@
+:root {
+  --bg: #fff;
+  --text: #000;
+  --sidebar-bg: #f3f2f1;
+  --link: #333;
+}
+
+body.dark {
+  --bg: #1e1e1e;
+  --text: #fff;
+  --sidebar-bg: #2d2d2d;
+  --link: #ddd;
+}
+
 body {
   margin: 0;
   font-family: Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
 }
 
 .app {
@@ -10,25 +26,29 @@ body {
 
 .sidebar {
   width: 200px;
-  background: #f3f2f1;
+  background: var(--sidebar-bg);
   padding: 10px;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar li {
+  margin: 8px 0;
 }
 
 .sidebar a {
   display: block;
-  margin: 8px 0;
   text-decoration: none;
-  color: #333;
+  color: var(--link);
 }
 
 .content {
   flex: 1;
   padding: 20px;
-}
-
-body.dark {
-  background: #1e1e1e;
-  color: #fff;
 }
 
 .doc-filters input,
@@ -55,6 +75,10 @@ body.dark {
   background: #e0e0e0;
 }
 
+.doc-table tr:focus {
+  outline: 2px solid #0078d4;
+}
+
 .doc-detail {
   width: 300px;
   padding-left: 16px;
@@ -69,4 +93,21 @@ body.dark {
   align-items: center;
   justify-content: center;
   margin-bottom: 10px;
+}
+
+@media (max-width: 768px) {
+  .app {
+    flex-direction: column;
+  }
+  .sidebar {
+    width: 100%;
+    display: flex;
+    overflow-x: auto;
+  }
+  .sidebar ul {
+    display: flex;
+  }
+  .sidebar li {
+    margin: 0 8px;
+  }
 }

--- a/server.ts
+++ b/server.ts
@@ -1,7 +1,63 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import multer from 'multer';
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+  role: string;
+  status: string;
+  lastActivity: string;
+}
+
+interface FieldInfo {
+  value: string;
+  confidence: number;
+}
+
+interface Document {
+  id: number;
+  fileName: string;
+  page: number;
+  type: string;
+  dg: boolean;
+  confidence: number;
+  fields: Record<string, FieldInfo>;
+  preview: string;
+}
+
+interface ReviewItem {
+  id: number;
+  file: string;
+  page: number;
+  reason: string;
+  indicator: string;
+  severity: string;
+  confidence: number;
+}
+
+interface Analytics {
+  totalFiles: number;
+  avgPages: number;
+  avgDocuments: number;
+  percentDG: number;
+}
+
+interface KafkaConfig {
+  brokers: string;
+  topic: string;
+  username: string;
+  password: string;
+}
+
+interface KafkaStatus {
+  connected: boolean;
+  messages: number;
+  lag: number;
+  errors: number;
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -12,12 +68,12 @@ app.use(express.static(path.join(__dirname, 'public')));
 const upload = multer({ dest: 'uploads/' });
 
 // Mock data
-let users = [
+let users: User[] = [
   { id: 1, name: 'Alice', email: 'alice@example.com', role: 'Admin', status: 'active', lastActivity: '2024-05-01' },
   { id: 2, name: 'Bob', email: 'bob@example.com', role: 'Analyst', status: 'inactive', lastActivity: '2024-04-15' }
 ];
 
-let documents = [
+let documents: Document[] = [
   {
     id: 1,
     fileName: 'invoice1.pdf',
@@ -50,32 +106,32 @@ let documents = [
   }
 ];
 
-let reviewQueue = [
+let reviewQueue: ReviewItem[] = [
   { id: 1, file: 'msds.pdf', page: 1, reason: 'Keyword match', indicator: 'UN 1234', severity: 'high', confidence: 0.88 }
 ];
 
-let analytics = {
+let analytics: Analytics = {
   totalFiles: 2,
   avgPages: 1,
   avgDocuments: 2,
   percentDG: 50
 };
 
-let kafkaConfig = { brokers: 'localhost:9092', topic: 'documents', username: '', password: '' };
-let kafkaStatus = { connected: true, messages: 0, lag: 0, errors: 0 };
+let kafkaConfig: KafkaConfig = { brokers: 'localhost:9092', topic: 'documents', username: '', password: '' };
+let kafkaStatus: KafkaStatus = { connected: true, messages: 0, lag: 0, errors: 0 };
 
 // Routes
-app.get('/api/users', (req, res) => {
+app.get('/api/users', (_req: Request, res: Response<User[]>) => {
   res.json(users);
 });
 
-app.post('/api/users', (req, res) => {
-  const user = { id: Date.now(), ...req.body };
+app.post('/api/users', (req: Request<{}, {}, Omit<User, 'id'>>, res: Response<User>) => {
+  const user: User = { id: Date.now(), ...req.body };
   users.push(user);
   res.status(201).json(user);
 });
 
-app.put('/api/users/:id', (req, res) => {
+app.put('/api/users/:id', (req: Request<{ id: string }, {}, Partial<User>>, res: Response<User>) => {
   const id = parseInt(req.params.id, 10);
   const idx = users.findIndex(u => u.id === id);
   if (idx === -1) return res.status(404).end();
@@ -83,7 +139,7 @@ app.put('/api/users/:id', (req, res) => {
   res.json(users[idx]);
 });
 
-app.delete('/api/users/:id', (req, res) => {
+app.delete('/api/users/:id', (req: Request<{ id: string }>, res: Response<User>) => {
   const id = parseInt(req.params.id, 10);
   const idx = users.findIndex(u => u.id === id);
   if (idx === -1) return res.status(404).end();
@@ -91,26 +147,26 @@ app.delete('/api/users/:id', (req, res) => {
   res.json(removed);
 });
 
-app.get('/api/documents', (req, res) => {
+app.get('/api/documents', (_req: Request, res: Response<Document[]>) => {
   res.json(documents);
 });
 
-app.get('/api/ingestion/config', (req, res) => {
+app.get('/api/ingestion/config', (_req: Request, res: Response<KafkaConfig>) => {
   res.json(kafkaConfig);
 });
 
-app.post('/api/ingestion/config', (req, res) => {
+app.post('/api/ingestion/config', (req: Request<{}, {}, Partial<KafkaConfig>>, res: Response<KafkaConfig>) => {
   kafkaConfig = { ...kafkaConfig, ...req.body };
   res.json(kafkaConfig);
 });
 
-app.get('/api/ingestion/status', (req, res) => {
+app.get('/api/ingestion/status', (_req: Request, res: Response<KafkaStatus>) => {
   res.json(kafkaStatus);
 });
 
-app.post('/api/ingest', upload.single('file'), (req, res) => {
+app.post('/api/ingest', upload.single('file'), (req: Request, res: Response<{ status: string }>) => {
   if (req.file) {
-    const doc = {
+    const doc: Document = {
       id: Date.now(),
       fileName: req.file.originalname,
       page: 1,
@@ -126,24 +182,24 @@ app.post('/api/ingest', upload.single('file'), (req, res) => {
   res.json({ status: 'received' });
 });
 
-app.get('/api/review', (req, res) => {
+app.get('/api/review', (_req: Request, res: Response<ReviewItem[]>) => {
   res.json(reviewQueue);
 });
 
-app.post('/api/review/:id/action', (req, res) => {
+app.post('/api/review/:id/action', (req: Request, res: Response<{ status: string; action: string }>) => {
   res.json({ status: 'recorded', action: req.body.action });
 });
 
-app.get('/api/analytics', (req, res) => {
+app.get('/api/analytics', (_req: Request, res: Response<Analytics>) => {
   res.json(analytics);
 });
 
 // Fallback to index.html
-app.get('*', (req, res) => {
+app.get('*', (_req: Request, res: Response) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
-const port = process.env.PORT || 3000;
+const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
 if (process.env.NODE_ENV !== 'test') {
   app.listen(port, () => console.log(`Server running on port ${port}`));
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import request from 'supertest';
-import app from '../server.js';
+import app from '../dist/server.js';
 
 test('GET /api/users', async () => {
   const res = await request(app).get('/api/users');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["server.ts"]
+}


### PR DESCRIPTION
## Summary
- migrate Express server to TypeScript with typed routes
- add responsive sidebar layout with dark/light mode
- improve document filters with clear button and keyboard navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8d98ec5b0832e86af0d4ce51506c4